### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync_mendeley_bib.yml
+++ b/.github/workflows/sync_mendeley_bib.yml
@@ -1,5 +1,8 @@
 name: Sync Mendeley Bib (Manual Only)
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/Distributed-ML/security/code-scanning/2](https://github.com/ajharris/Distributed-ML/security/code-scanning/2)

To fix this issue without altering any existing behavior, add a `permissions` block granting the minimal necessary privileges to the job. In this case, since no step writes to the repository or needs additional token scopes, set `permissions: contents: read` at either the workflow root or beneath the `sync-bib` job (line 7). Setting it at the job level is more targeted, though putting it at the root covers all jobs for future expansion. You only need to edit the YAML in `.github/workflows/sync_mendeley_bib.yml`, inserting:

```yaml
permissions:
  contents: read
```

either after the workflow name or within the `sync-bib` job. For clarity and convention, add it directly after the `name`–`on` block (that is, after line 2 and before line 3).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
